### PR TITLE
Updated .travis.yml to use new build strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ compiler:
 branches:
   only:
     - master
-    - release
-    - hotfixes
     - develop
 
 before_install:


### PR DESCRIPTION
From now on, only `master` and `develop` branches will be build. 
No direct commits are allowed on these, only pull requests. This is to avoid stupid builds, since only finished features will be tested.

Closes #48.