### PR TITLE
Error tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRC_DIR= src
 INC_DIR= src
 OBJ_DIR= obj
-OBJECT_FILES= index_bwt.o index_sar.o index_txt.o index_sym.o index_ann.o index.o blocksearch.o
+OBJECT_FILES= index_bwt.o index_sar.o index_txt.o index_sym.o index_ann.o index.o errhandler.o blocksearch.o
 SOURCE_FILES= mapper.c divsufsort.c
 HEADER_FILES= mapper.h divsufsort.h
 OTHER_FILES = Makefile

--- a/src/blocksearch.c
+++ b/src/blocksearch.c
@@ -4,7 +4,7 @@
 ** Block-search functions
 */
 
-void
+int
 blocksc_trail
 (
  uint8_t     * query,
@@ -31,7 +31,9 @@ blocksc_trail
 //       tau    = floor(tau_max/2)
 //     Then extend right up to tau_max.
 {
-   if (trail >= slen) return;
+   if (trail >= slen) {
+      return 0;
+   }
 
    // Index info.
    bwt_t * bwt = bwt_get_bwt(qarray[slen]);
@@ -52,7 +54,9 @@ blocksc_trail
 
    // Return if num(N) > tau or tau == 0 and not in last strand.
    tau -= n_cnt;
-   if (tau < 0 || (tau == 0 && !last_fragment)) return;
+   if (tau < 0 || (tau == 0 && !last_fragment)) {
+      return 0;
+   }
 
    // Split block.
    int pos_r = slen/2 + (last_fragment ? slen%2 : 0);
@@ -60,7 +64,7 @@ blocksc_trail
 
    // Recursive call on left block, don't compute if current data is valid (trail).
    if (trail < pos_r) {
-      blocksearch_trail_rec(query, 0, pos_r-1, tau_l+1, trail, bwt, tree->next_l);
+      error_test(blocksearch_trail_rec(query, 0, pos_r-1, tau_l+1, trail, bwt, tree->next_l) == -1);
       // Remove out-of-boundary hits (lexicographically bigger than query).
       int64_t max_sa_pos = bwt_start(qarray[pos_r]) + bwt_size(qarray[pos_r]);
       int i = 0;
@@ -77,7 +81,7 @@ blocksc_trail
    // Extend left block to the right.
    for (int i = 0; i < tree->next_l->stack->pos; i++) {
       spath_t p = tree->next_l->stack->path[i];
-      scsearch_fw(p, query, pos_r, slen-1, tau, p.score, 0, 1, &(tree->stack));
+      error_test(scsearch_fw(p, query, pos_r, slen-1, tau, p.score, 0, 1, &(tree->stack)) == -1);
    }
 
    // Add num(N) mismatches to hits.
@@ -85,11 +89,14 @@ blocksc_trail
       for (int i = 0; i < tree->stack->pos; i++)
          tree->stack->path[i].score += n_cnt;
 
-   return;
+   return 0;
+
+ failure_return:
+   return -1;
 }
 
 
-void
+int
 blocksearch_trail_rec
 (
  uint8_t   * query,
@@ -110,8 +117,8 @@ blocksearch_trail_rec
    // Compute single block and return.
    if (blocks == 1) {
       spath_t empty = {.bwtq = bwt_new_query(bwt), .score = 0};
-      seqsearch_bw(empty, query, end, pos, 0, 0, 0, &(tree->stack));
-      return;
+      error_test(seqsearch_bw(empty, query, end, pos, 0, 0, 0, &(tree->stack)) == -1);
+      return 0;
    }
 
    // Split block.
@@ -125,22 +132,25 @@ blocksearch_trail_rec
 
    // Recursive call on left block, don't compute if current data is valid (trail).
    if (trail < pos_r)
-      blocksearch_trail_rec(query, pos, end_l, blk_l, trail, bwt, tree->next_l);
+      error_test(blocksearch_trail_rec(query, pos, end_l, blk_l, trail, bwt, tree->next_l) == -1);
    // Extend left block to the right.
    for (int i = 0; i < tree->next_l->stack->pos; i++) {
       spath_t p = tree->next_l->stack->path[i];
-      seqsearch_fw(p, query, pos_r, end, blocks-1, p.score, 0, &(tree->stack));
+      error_test(seqsearch_fw(p, query, pos_r, end, blocks-1, p.score, 0, &(tree->stack)) == -1);
    }
 
    // Recursive call on right block.
-   blocksearch_trail_rec(query, pos_r, end, blk_r, trail, bwt, tree->next_r);
+   error_test(blocksearch_trail_rec(query, pos_r, end, blk_r, trail, bwt, tree->next_r) == -1);
    // Extend right block to the left.
    for (int i = 0; i < tree->next_r->stack->pos; i++) {
       spath_t p = tree->next_r->stack->path[i];
-      seqsearch_bw(p, query, end_l, pos, blocks-1, p.score, blk_l, &(tree->stack));
+      error_test(seqsearch_bw(p, query, end_l, pos, blocks-1, p.score, blk_l, &(tree->stack)) == -1);
    }
 
-   return;
+   return 0;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -164,9 +174,10 @@ seqsearch_bw
    bwtquery_t  * q   = path.bwtq;
    bwt_t       * bwt = bwt_get_bwt(q);
    bwtquery_t ** qv  = bwt_new_vec(bwt);
+   error_test(qv == NULL);
 
    // Extend sequence.
-   bwt_query_all(BWT_QUERY_PREFIX, q, qv);
+   error_test(bwt_query_all(BWT_QUERY_PREFIX, q, qv) == -1);
 
    // Iterate over nt.
    int num_symb = sym_count(txt_get_symbols(bwt_get_text(bwt)));
@@ -188,24 +199,28 @@ seqsearch_bw
       // Dash if max tau is reached.
       if (s == tau) {
          if (s - score_ref >= score_diff) {
-            seqdash_bw(p, query, pos-1, end, hits);
+            error_test(seqdash_bw(p, query, pos-1, end, hits) == -1);
          }
       }
       // If depth is reached.
       else if (pos == end) {
          // Check score difference and store hit.
          if (s - score_ref >= score_diff) {
-            path_push(p, hits);
+            error_test(path_push(p, hits) == -1);
          }
       } else {
          // Recursive call.
-         seqsearch_bw(p, query, pos-1, end, tau, score_ref, score_diff, hits);
+         error_test(seqsearch_bw(p, query, pos-1, end, tau, score_ref, score_diff, hits) == -1);
       }
    }
 
    bwt_free_vec(qv);
 
    return 0;
+
+ failure_return:
+   bwt_free_vec(qv);
+   return -1;
 }
 
 
@@ -225,9 +240,10 @@ seqsearch_fw
    bwtquery_t  * q   = path.bwtq;
    bwt_t       * bwt = bwt_get_bwt(q);
    bwtquery_t ** qv  = bwt_new_vec(bwt);
+   error_test(qv == NULL);
 
    // Extend sequence.
-   bwt_query_all(BWT_QUERY_SUFFIX, q, qv);
+   error_test(bwt_query_all(BWT_QUERY_SUFFIX, q, qv) == -1);
 
    // Iterate over nt.
    int num_symb = sym_count(txt_get_symbols(bwt_get_text(bwt)));
@@ -249,22 +265,26 @@ seqsearch_fw
       // Dash if max tau is reached.
       if (s == tau) {
          if (s - score_ref >= score_diff)
-            seqdash_fw(p, query, pos+1, end, hits);
+            error_test(seqdash_fw(p, query, pos+1, end, hits) == -1);
       }
       // If depth is reached.
       else if (pos == end) {
          // Check score difference and store hit.
          if (s - score_ref >= score_diff)
-            path_push(p, hits);
+            error_test(path_push(p, hits) == -1);
       } else {
          // Recursive call.
-         seqsearch_fw(p, query, pos+1, end, tau, score_ref, score_diff, hits);
+         error_test(seqsearch_fw(p, query, pos+1, end, tau, score_ref, score_diff, hits) == -1);
       }
    }
 
    bwt_free_vec(qv);
 
    return 0;
+
+ failure_return:
+   bwt_free_vec(qv);
+   return -1;
 }
 
 
@@ -285,9 +305,10 @@ scsearch_fw
    bwtquery_t  * q   = path.bwtq;
    bwt_t       * bwt = bwt_get_bwt(q);
    bwtquery_t ** qv  = bwt_new_vec(bwt);
+   error_test(qv == NULL);
 
    // Extend sequence.
-   bwt_query_all(BWT_QUERY_SUFFIX, q, qv);
+   error_test(bwt_query_all(BWT_QUERY_SUFFIX, q, qv) == -1);
 
    // Iterate over nt.
    int num_symb = sym_count(txt_get_symbols(bwt_get_text(bwt)));
@@ -310,23 +331,27 @@ scsearch_fw
       // Dash if max tau is reached.
       if (s == tau) {
          if (s - score_ref >= score_diff)
-            seqdash_fw(p, query, pos+1, end, hits);
+            error_test(seqdash_fw(p, query, pos+1, end, hits) == -1);
       }
       // If depth is reached.
       else if (pos == end) {
          // Check score difference and store hit.
          if (s - score_ref >= score_diff)
-            path_push(p, hits);
+            error_test(path_push(p, hits) == -1);
       } else {
          // Recursive call.
          int bnd = boundary && (nt == query[pos]);
-         scsearch_fw(p, query, pos+1, end, tau, score_ref, score_diff, bnd, hits);
+         error_test(scsearch_fw(p, query, pos+1, end, tau, score_ref, score_diff, bnd, hits) == -1);
       }
    }
 
    bwt_free_vec(qv);
 
    return 0;
+
+ failure_return:
+   bwt_free_vec(qv);
+   return -1;
 }
 
 
@@ -342,12 +367,13 @@ seqdash_fw
 {
    bwtquery_t  * q   = path.bwtq;
    bwt_t       * bwt = bwt_get_bwt(q);
+   bwtquery_t ** qv  = NULL;
 
    // Dash until the end of the search region.
    for (int d = pos; d <= end; d++) {
       // Do not allow any mismatch. If sequence does not exist, return.
       if (__builtin_expect(query[d] != UNKNOWN_BASE,1)) {
-         bwt_query(query[d], BWT_QUERY_SUFFIX, q, q);
+         error_test(bwt_query(query[d], BWT_QUERY_SUFFIX, q, q) == -1);
          if (bwt_size(q) < 1)
             return 0;
       } 
@@ -357,8 +383,10 @@ seqdash_fw
          aln_bit_set(&path, d);
 
          // Extend all branches.
-         bwtquery_t ** qv  = bwt_new_vec(bwt);
-         bwt_query_all(BWT_QUERY_SUFFIX, q, qv);
+         qv = bwt_new_vec(bwt);
+         error_test(qv == NULL);
+         
+         error_test(bwt_query_all(BWT_QUERY_SUFFIX, q, qv) == -1);
 
          // Follow branches.
          int num_symb = sym_count(txt_get_symbols(bwt_get_text(bwt)));
@@ -366,18 +394,23 @@ seqdash_fw
             if (bwt_size(qv[i]) < 1)
                continue;
             path.bwtq = qv[i];
-            seqdash_fw(path, query, d+1, end, hits);
+            error_test(seqdash_fw(path, query, d+1, end, hits) == -1);
          }
          
          // Free query vector.
          bwt_free_vec(qv);
+         qv = NULL;
          return 0;
       }
    }
    // Sequence found, push to hit stack.
    path.bwtq = q;
-   path_push(path, hits);
+   error_test(path_push(path, hits) == -1);
    return 0;
+   
+ failure_return:
+   bwt_free_vec(qv);
+   return -1;
 }
 
 
@@ -393,12 +426,13 @@ seqdash_bw
 {
    bwtquery_t  * q   = path.bwtq;
    bwt_t       * bwt = bwt_get_bwt(q);
+   bwtquery_t ** qv  = NULL;
 
    // Dash until the end of the search region.
    for (int d = pos; d >= end; d--) {
       // Do not allow any mismatch. If sequence does not exist, return.
       if (__builtin_expect(query[d] != UNKNOWN_BASE,1)) {
-         bwt_query(query[d], BWT_QUERY_PREFIX, q, q);
+         error_test(bwt_query(query[d], BWT_QUERY_PREFIX, q, q) == -1);
          if (bwt_size(q) < 1)
             return 0;
       }
@@ -408,8 +442,10 @@ seqdash_bw
          aln_bit_set(&path, d);
 
          // Extend all branches.
-         bwtquery_t ** qv  = bwt_new_vec(bwt);
-         bwt_query_all(BWT_QUERY_PREFIX, q, qv);
+         qv  = bwt_new_vec(bwt);
+         error_test(qv == NULL);
+         
+         error_test(bwt_query_all(BWT_QUERY_PREFIX, q, qv) == -1);
 
          // Follow branches.
          int num_symb = sym_count(txt_get_symbols(bwt_get_text(bwt)));
@@ -417,18 +453,23 @@ seqdash_bw
             if (bwt_size(qv[i]) < 1)
                continue;
             path.bwtq = qv[i];
-            seqdash_bw(path, query, d-1, end, hits);
+            error_test(seqdash_bw(path, query, d-1, end, hits) == -1);
          }
          
          // Free query vector.
          bwt_free_vec(qv);
+         qv = NULL;
          return 0;
       }
    }
    // Sequence found, push to hit stack.
    path.bwtq = q;
-   path_push(path, hits);
+   error_test(path_push(path, hits) == -1);
    return 0;
+
+ failure_return:
+   bwt_free_vec(qv);
+   return -1;
 }
 
 
@@ -446,12 +487,15 @@ pathstack_new
    if (n_elem < 1) n_elem = 1;
    // Alloc structure.
    pathstack_t * stack = malloc(sizeof(pathstack_t) + n_elem * sizeof(spath_t));
-   if (stack == NULL)
-      return NULL;
+   error_test_mem(stack);
    // Empty stack.
    stack->pos = 0;
    stack->size = n_elem;
    return stack;
+
+ failure_return:
+   free(stack);
+   return NULL;
 }
 
 
@@ -461,7 +505,13 @@ alloc_stack_tree
  int tau
 )
 {
-   return alloc_stack_tree_rec(tau+1);
+   pstree_t * pst = alloc_stack_tree_rec(tau+1);
+   error_test(pst == NULL);
+
+   return pst;
+
+ failure_return:
+   return NULL;
 }
 
 
@@ -471,21 +521,38 @@ alloc_stack_tree_rec
  int        block
 )
 {
-   // End of tree, return null.
-   if (block == 0) return NULL;
    // Alloc stack for this node.
    pstree_t * node = calloc(1,sizeof(pstree_t));
+   error_test_mem(node);
+   node->stack = NULL;
+
    node->stack = pathstack_new(PATHSTACK_DEF_SIZE);
+   error_test(node->stack == NULL);
+
    // Build tree with recursive calls.
    if (block > 1) {
-      node->next_l = alloc_stack_tree_rec((block >> 1) + (block & 1));
-      node->next_r = alloc_stack_tree_rec(block >> 1);
+      if ((block >> 1) + (block & 1) > 0) {
+         node->next_l = alloc_stack_tree_rec((block >> 1) + (block & 1));
+         error_test(node->next_l == NULL);
+      } else {
+         node->next_l = NULL;
+      }
+
+      if (block >> 1 > 0) {
+         node->next_r = alloc_stack_tree_rec(block >> 1);
+         error_test(node->next_r == NULL);
+      } else {
+         node->next_r = NULL;
+      }
    } else {
       node->next_l = node->next_r = NULL;
    }
    return node;
-}
 
+ failure_return:
+   free_stack_tree(node);
+   return NULL;
+}
 
 void
 free_stack_tree
@@ -493,8 +560,12 @@ free_stack_tree
  pstree_t * tree
 )
 {
-   for (int i = 0; i < tree->stack->pos; i++) {
-      free(tree->stack->path[i].bwtq);
+   if (tree == NULL)
+      return;
+   if (tree->stack != NULL) {
+      for (int i = 0; i < tree->stack->pos; i++) {
+            free(tree->stack->path[i].bwtq);
+      }
    }
    free(tree->stack);
    if (tree->next_l != NULL) free_stack_tree(tree->next_l);
@@ -515,14 +586,18 @@ path_push
    if (stack->pos >= stack->size) {
       size_t newsize = stack->size * 2;
       *pstack = stack = realloc(stack, sizeof(pathstack_t) + newsize * sizeof(spath_t));
-      if (stack == NULL) return -1;
+      error_test_mem(stack);
       stack->size = newsize;
    }
    // Store element.
    stack->path[stack->pos] = p;
    stack->path[stack->pos].bwtq = bwt_dup_query(p.bwtq);
+   error_test(stack->path[stack->pos].bwtq == NULL);
    stack->pos++;
    return 0;
+
+ failure_return:
+   return -1;
 }
 
 

--- a/src/blocksearch.h
+++ b/src/blocksearch.h
@@ -1,7 +1,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "errhandler.h"
 #include "index_bwt.h"
+
 
 #ifndef _BLOCKSEARCH_H
 #define _BLOCKSEARCH_H

--- a/src/blocksearch.h
+++ b/src/blocksearch.h
@@ -32,8 +32,8 @@ struct pstree_t {
 };
 
 // Block-search functions.
-void          blocksc_trail          (uint8_t *, bwtquery_t **, int, int, int, pstree_t *);
-void          blocksearch_trail_rec  (uint8_t *, int, int, int, int, bwt_t *, pstree_t *);
+int           blocksc_trail          (uint8_t *, bwtquery_t **, int, int, int, pstree_t *);
+int           blocksearch_trail_rec  (uint8_t *, int, int, int, int, bwt_t *, pstree_t *);
 // Search functions.
 int           scsearch_fw            (spath_t, uint8_t *, int, int, int, int, int, int, pathstack_t **);
 int           seqsearch_fw           (spath_t, uint8_t *, int, int, int, int, int, pathstack_t **);

--- a/src/errhandler.c
+++ b/src/errhandler.c
@@ -1,0 +1,16 @@
+#include "errhandler.h"
+
+void
+warning
+(
+ const char  * msg,
+ const char  * file,
+ const char  * func,
+ const int     line
+)
+{
+   if (msg == NULL) 
+      fprintf(stderr, "%s\t(%s:%d)\n", file, func, line);      
+   else
+      fprintf(stderr, "%s\t(%s:%d): %s\n", file, func, line, msg);
+}

--- a/src/errhandler.c
+++ b/src/errhandler.c
@@ -12,5 +12,5 @@ warning
    if (msg == NULL) 
       fprintf(stderr, "%s\t(%s:%d)\n", file, func, line);      
    else
-      fprintf(stderr, "%s\t(%s:%d): %s\n", file, func, line, msg);
+      fprintf(stderr, "%s\t(%s:%d) error: %s\n", file, func, line, msg);
 }

--- a/src/errhandler.h
+++ b/src/errhandler.h
@@ -1,0 +1,39 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef
+#define ERRHANDLER_H_
+
+// Macros to throw errors.
+
+#define error_test_mem(x) do { \
+   if ((x) == NULL) { \
+      warning("memory error", __FILE__, __func__, __LINE__);     \
+      goto failure_return; \
+   }} while (0)
+
+#define error_test_def(x) do { \
+   if (!(x)) { \
+      warning(strerror(errno), __FILE__, __func__, __LINE__);    \
+      goto failure_return; \
+   }} while (0)
+
+#define error_test_msg(x,m) do { \
+   if (!(x)) { \
+      warning(m, __FILE__, __func__, __LINE__); \
+      goto failure_return; \
+   }} while (0)
+
+// Macros to propagate errors.
+
+#define error_test(x) do { \
+   if (!(x)) { \
+   warning(NULL, __FILE__, __func__, __LINE__); \
+   goto failure_return; \
+   }} while (0)
+
+// Helper functions.
+void    warning   (const char * msg, const char * file, const char * func, const int line);
+
+#endif

--- a/src/errhandler.h
+++ b/src/errhandler.h
@@ -1,8 +1,9 @@
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef
+#ifndef ERRHANDLER_H_
 #define ERRHANDLER_H_
 
 // Macros to throw errors.
@@ -14,24 +15,40 @@
    }} while (0)
 
 #define error_test_def(x) do { \
-   if (!(x)) { \
+   if ((x)) { \
       warning(strerror(errno), __FILE__, __func__, __LINE__);    \
       goto failure_return; \
    }} while (0)
 
 #define error_test_msg(x,m) do { \
-   if (!(x)) { \
+   if ((x)) { \
       warning(m, __FILE__, __func__, __LINE__); \
       goto failure_return; \
    }} while (0)
 
+#define error_throw_def() do { \
+   warning(strerror(errno), __FILE__, __func__, __LINE__); \
+   goto failure_return; \
+   } while (0)
+
+#define error_throw_msg(m) do { \
+   warning(m, __FILE__, __func__, __LINE__); \
+   goto failure_return; \
+   } while (0)
+
 // Macros to propagate errors.
 
 #define error_test(x) do { \
-   if (!(x)) { \
+   if ((x)) { \
+      warning(NULL, __FILE__, __func__, __LINE__); \
+      goto failure_return; \
+   }} while (0)
+
+#define error_throw() do { \
    warning(NULL, __FILE__, __func__, __LINE__); \
    goto failure_return; \
-   }} while (0)
+   } while (0)
+
 
 // Helper functions.
 void    warning   (const char * msg, const char * file, const char * func, const int line);

--- a/src/index.c
+++ b/src/index.c
@@ -17,17 +17,19 @@ index_read
 ** .ann.*
 */
 {
-   if (filename_base == NULL)
-      return NULL;
-
+   // Declare variables.
    char * file_path = NULL;
+   index_t * index = NULL;
+
+   // Check arguments.
+   error_test_msg(filename_base == NULL, "argument 'filename_base' is NULL.");
 
    // Alloc index structure.
-   index_t * index = malloc(sizeof(index_t));
-   if (index == NULL)
-      return NULL;
+   index = malloc(sizeof(index_t));
+   error_test_mem(index);
 
    index->fname_base = strdup(filename_base);
+   error_test_mem(index->fname_base);
    index->ann_cnt = 0;
    index->sym = NULL;
    index->txt = NULL;
@@ -36,32 +38,27 @@ index_read
    index->ann = NULL;
    
    file_path = malloc(strlen(filename_base)+7);
-   if (file_path == NULL)
-      goto failure_return;
+   error_test_mem(file_path);
 
    // sym
    sprintf(file_path, "%s.sym", filename_base);
    index->sym = sym_file_read(file_path);
-   if (index->sym == NULL)
-      goto failure_return;
+   error_test(index->sym == NULL);
 
    // txt
    sprintf(file_path, "%s.txt", filename_base);
    index->txt = txt_file_read(file_path, index->sym);
-   if (index->txt == NULL)
-      goto failure_return;
+   error_test(index->txt == NULL);
 
    // sar
    sprintf(file_path, "%s.sar", filename_base);
    index->sar = sar_file_read(file_path);
-   if (index->sar == NULL)
-      goto failure_return;
+   error_test(index->sar == NULL);
 
    // bwt
    sprintf(file_path, "%s.bwt", filename_base);
    index->bwt = bwt_file_read(file_path, index->txt);
-   if (index->bwt == NULL)
-      goto failure_return;
+   error_test(index->bwt == NULL);
 
    // ann glob
    glob_t gbuf;
@@ -70,36 +67,22 @@ index_read
 
    // alloc ann list
    index->ann = malloc(gbuf.gl_pathc * sizeof(void *));
-   if (index->ann == NULL)
-      goto failure_return;
+   error_test(index->ann == NULL);
 
    // ann
    index->ann_cnt = gbuf.gl_pathc;
    for (int i = 0; i < index->ann_cnt; i++) {
       index->ann[i] = ann_file_read(gbuf.gl_pathv[i]);
-      if (index->ann[i] == NULL)
-         goto failure_return;
+      error_test(index->ann[i] == NULL);
    }
 
-
    free(file_path);
-
    return index;
-   
 
  failure_return:
-   sym_free(index->sym);
-   txt_free(index->txt);
-   sar_free(index->sar);
-   bwt_free(index->bwt);
-   for (int i = 0; i < index->ann_cnt; i++) {
-      ann_free(index->ann[i]);
-   }
-   free(index->ann);
-   free(index);
+   index_free(index);
    free(file_path);
    return NULL;
-   
 }
 
 
@@ -110,14 +93,14 @@ index_build
   char * filename_base
 )
 {
-   if (ref_txt == NULL || filename_base == NULL)
-      return NULL;
-
    char * file_path = NULL;
+   index_t * index = NULL;
 
-   index_t * index = malloc(sizeof(index_t));
-   if (index == NULL)
-      goto failure_return;
+   error_test_msg(ref_txt == NULL, "argument 'ref_txt' is NULL.");
+   error_test_msg(filename_base == NULL, "argument 'filename_base' is NULL.");
+
+   index = malloc(sizeof(index_t));
+   error_test_mem(index);
 
    index->sym = NULL;
    index->txt = NULL;
@@ -127,43 +110,36 @@ index_build
    index->ann_cnt = 0;
 
    index->fname_base = strdup(filename_base);
+   error_test_mem(index->fname_base);
 
    // Compute index structures.
    index->txt = read_fasta(ref_txt);
-   if (index->txt == NULL)
-      goto failure_return;
+   error_test(index->txt == NULL);
 
    index->sym = txt_get_symbols(index->txt);
-   if (index->sym == NULL)
-      goto failure_return;
+   error_test(index->sym == NULL);
 
    index->sar = sar_build(index->txt);
-   if (index->sar == NULL)
-      goto failure_return;
+   error_test(index->sar == NULL);
 
    index->bwt = bwt_build(index->txt, index->sar);
-   if (index->bwt == NULL)
-      goto failure_return;
-
+   error_test(index->bwt == NULL);
 
    // Write to output files.
    file_path = malloc(strlen(filename_base)+5);
+   error_test_mem(file_path);
 
    sprintf(file_path, "%s.sym", filename_base);
-   if (sym_file_write(file_path, index->sym))
-      goto failure_return;
+   error_test(sym_file_write(file_path, index->sym) == -1);
 
    sprintf(file_path, "%s.txt", filename_base);
-   if (txt_file_write(file_path, index->txt))
-      goto failure_return;
+   error_test(txt_file_write(file_path, index->txt) == -1);
 
    sprintf(file_path, "%s.sar", filename_base);
-   if (sar_file_write(file_path, index->sar))
-      goto failure_return;
+   error_test(sar_file_write(file_path, index->sar) == -1);
 
    sprintf(file_path, "%s.bwt", filename_base);
-   if (bwt_file_write(file_path, index->bwt))
-      goto failure_return;
+   error_test(bwt_file_write(file_path, index->bwt) == -1);
 
    free(file_path);
 
@@ -185,8 +161,14 @@ index_ann_new
  index_t  * index
 )
 {
-   if (index == NULL)
-      return -1;
+   // Declare variables.
+   char * file_path = NULL;
+
+   // Check arguments.
+   error_test_msg(index == NULL, "argument 'index' is NULL.");
+   error_test_msg(kmer < 1, "argument 'kmer' must be greater than 0.");
+   error_test_msg(threads < 1, "argument 'threads' must be greater than 0.");
+   error_test_msg(tau < 1, "argument 'tau' must be greater than 0");
    
    // Check whether annotation exists.
    for (int i = 0; i < index->ann_cnt; i++) {
@@ -196,22 +178,27 @@ index_ann_new
 
    // Realloc annotation list.
    index->ann = realloc(index->ann, (index->ann_cnt+1) * sizeof(void *));
-   if (index->ann == NULL)
-      return -1;
+   error_test_mem(index->ann);
 
    // Compute annotation.
    index->ann[index->ann_cnt] = ann_build(kmer, tau, index->bwt, index->sar, threads);
-   if (index->ann[index->ann_cnt] == NULL)
-      return -1;
+   error_test(index->ann[index->ann_cnt] == NULL);
    
    // Write to file.
-   char * file_path = malloc(strlen(index->fname_base) + 100);
+   file_path = malloc(strlen(index->fname_base) + 100);
+   error_test_mem(file_path);
    sprintf(file_path, "%s.ann.%d.%d", index->fname_base, kmer, tau);
-   ann_file_write(file_path, index->ann[index->ann_cnt]);
+   error_test(ann_file_write(file_path, index->ann[index->ann_cnt]) == -1);
 
    index->ann_cnt++;
 
+   free(file_path);
+
    return 0;
+
+ failure_return:
+   free(file_path);
+   return -1;
 }
 
 
@@ -247,30 +234,31 @@ read_fasta
   char * filename
 )
 {
+   // Declare variables.
+   FILE * input   = NULL;
+   char * seqname = NULL;
+   char * buffer  = NULL;
+   txt_t * txt    = NULL;
+
+   // Check arguments.
+   error_test_msg(filename == NULL, "argument 'filename' is NULL.");
+
    // Files
-   FILE * input = fopen(filename,"r");
-   if (input == NULL)
-      return NULL;
+   input = fopen(filename,"r");
+   error_test_def(input == NULL);
 
    // Check FASTA format
-   if (fgetc(input) != '>')
-      return NULL;
+   error_test_msg(fgetc(input) != '>', "incorrect input format (fgetc).");
    
    ungetc('>', input);
 
-   // Alloc vars.
-   char * seqname = NULL;
-   char * buffer  = NULL;
-
    // Alloc txt structure.
-   txt_t * txt = txt_new(sym_new_dna());
-   if (txt == NULL)
-      goto failure_return;
+   txt = txt_new(sym_new_dna());
+   error_test(txt == NULL);
 
    // File read vars
    buffer  = malloc(INDEX_FASTA_BUFFER);
-   if (buffer == NULL)
-      goto failure_return;
+   error_test_mem(buffer);
 
    ssize_t   rlen;
    size_t    sz     = INDEX_FASTA_BUFFER;
@@ -280,8 +268,7 @@ read_fasta
       if (buffer[0] == '>') {
          // Commit previous sequence
          if (seqname != NULL) {
-            if (txt_commit_seq(seqname, txt) == -1)
-               goto failure_return;
+            error_test(txt_commit_seq(seqname, txt) == -1);
          }
          // Parse new sequence name (from '>' to first space or \0).
          buffer[rlen-1] = 0;
@@ -292,27 +279,24 @@ read_fasta
          int k = beg;
          while (buffer[k] != ' ' && buffer[k] != 0) k++;
          buffer[k] = 0;
-         if (beg == k)
-            goto failure_return;
+         error_test_msg(beg == k, "found empty sequence name.");
          // Store sequence name.
          seqname = strdup(buffer+beg);
-
+         error_test_mem(seqname);
       } else {
          // Remove newline character.
          if (buffer[rlen-1] == '\n') {
             buffer[rlen-1] = 0;
          }
          // Append sequence.
-         if (txt_append(buffer, txt) == -1)
-            goto failure_return;
+         error_test(txt_append(buffer, txt) == -1);
       }
    }
 
    // Commit last sequence.
-   txt_commit_seq(seqname, txt);
+   error_test(txt_commit_seq(seqname, txt) == -1);
    // Generate reverse complement.
-   if (txt_commit_rc(txt) == -1)
-      goto failure_return;
+   error_test(txt_commit_rc(txt) == -1);
 
    free(buffer);
    free(seqname);
@@ -321,7 +305,8 @@ read_fasta
    return txt;
    
  failure_return:
-   fclose(input);
+   if (input != NULL)
+      fclose(input);
    free(buffer);
    free(seqname);
    txt_free(txt);

--- a/src/index.h
+++ b/src/index.h
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <glob.h>
+#include "errhandler.h"
 #include "index_sym.h"
 #include "index_txt.h"
 #include "index_sar.h"

--- a/src/index_ann.c
+++ b/src/index_ann.c
@@ -203,6 +203,8 @@ ann_build
    ann->tau  = tau;
    ann->size = tlen/2;
    ann->info = calloc(ann->size, sizeof(uint8_t));
+   ann->mmap_len = 0;
+   ann->mmap_ptr = NULL;
    error_test_mem(ann->info);
 
    // Compute and store annotation from info.

--- a/src/index_ann.h
+++ b/src/index_ann.h
@@ -6,7 +6,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
-
+#include "errhandler.h"
 #include "index_sar.h"
 #include "index_bwt.h"
 #include "blocksearch.h"

--- a/src/index_bwt.h
+++ b/src/index_bwt.h
@@ -5,8 +5,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
-
-
+#include "errhandler.h"
 #include "index_sar.h"
 
 #ifndef _INDEX_BWT_H

--- a/src/index_sar.c
+++ b/src/index_sar.c
@@ -21,25 +21,22 @@ sar_build
   txt_t  * txt
 )
 {
-   if (txt == NULL)
-      return NULL;
-
-   // Alloc memory.
+   // Declare variables.
    char      * data = NULL;
    saidx64_t * sa   = NULL;
    sar_t     * sar  = NULL;
 
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+
+   // Alloc memory.
    data = malloc(txt_length(txt)*sizeof(uint8_t));
-   if (data == NULL)
-      goto free_and_return;
+   error_test_mem(data);
 
    sa   = malloc(txt_length(txt)*sizeof(saidx64_t));
-   if (sa == NULL)
-       goto free_and_return;
+   error_test_mem(sa);
 
    sar  = malloc(sizeof(sar_t));
-   if (sar == NULL)
-      goto free_and_return;
+   error_test_mem(sar);
 
    sar->sa = NULL;
    sar->mmap_len = 0;
@@ -57,12 +54,12 @@ sar_build
    
    // Compact array.
    sar->sa = (int64_t *)sa;
-   compact_array(sar, txt_length(txt));
+   error_test( compact_array(sar, txt_length(txt)) == -1 );
 
    free(data);
    return sar;
 
- free_and_return:
+ failure_return:
    free(data);
    free(sa);
    sar_free(sar);
@@ -97,23 +94,26 @@ sar_get
 )
 {
    // Check arguments.
-   if (sar == NULL)
-      return -1;
+   error_test_msg(sar == NULL, "argument 'sar' is NULL.");
 
    int64_t sar_txt_len = (64*sar->sar_len)/sar->sar_bits;
-   if (pos < 0 || pos >= sar_txt_len)
-      return -1;
+   error_test_msg(pos < 0, "index must be positive.");
+   error_test_msg(pos >= sar_txt_len, "index out of bounds.");
 
    // Fetch word of 'sar_bits' bits in suffix array.
    uint64_t mask = ((uint64_t)0xFFFFFFFFFFFFFFFF) >> (64 - sar->sar_bits);
    uint64_t bit = pos*sar->sar_bits;
    uint64_t word = bit/64;
    bit %= 64;
+
    // Cast words to unsigned to avoid right shift with 1's.
    if (bit + sar->sar_bits > 64)
       return ((((uint64_t)sar->sa[word] >> bit) & mask) | ((uint64_t)sar->sa[word+1] & mask) << (64-bit)) & mask;
    else
       return ((uint64_t)sar->sa[word] >> bit) & mask;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -127,12 +127,13 @@ sar_get_range
 )
 {
    // Check arguments.
-   if (vec == NULL || sar == NULL)
-      return -1;
+   error_test_msg(vec == NULL, "argument 'vec' is NULL.");
+   error_test_msg(sar == NULL, "argument 'sar' is NULL.");
 
    int64_t sar_txt_len = (64*sar->sar_len)/sar->sar_bits;
-   if (beg < 0 || size < 1 || beg + size > sar_txt_len)
-      return -1;
+   error_test_msg(beg < 0, "'beg' index must be positive.");
+   error_test_msg(size < 1, "'size' must be greater than 0.");
+   error_test_msg(beg + size > sar_txt_len, "range out of bounds.");
 
    // Fetch words of 'sar_bits' bits and store them in vec.
    uint64_t mask = ((uint64_t)0xFFFFFFFFFFFFFFFF) >> (64 - sar->sar_bits);
@@ -154,6 +155,9 @@ sar_get_range
       if (bit == 0) w = sar->sa[++word];
    }
    return 0;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -165,14 +169,16 @@ sar_file_write
   sar_t  * sar
 )
 {
+   // Declare variables.
+   int fd = -1;
+
    // Check arguments.
-   if (filename == NULL || sar == NULL)
-      return -1;
+   error_test_msg(filename == NULL, "argument 'filename' is NULL.");
+   error_test_msg(sar == NULL, "argument 'sar' is NULL.");
 
    // Open file.
-   int fd = creat(filename, 0644);
-   if (fd == -1)
-      return -1;
+   fd = creat(filename, 0644);
+   error_test_def(fd == -1);
 
    // Write data.
    ssize_t  e_cnt = 0;
@@ -180,31 +186,31 @@ sar_file_write
    uint64_t magic = SAR_FILE_MAGICNO;
 
    // Write magic.
-   if (write(fd, &magic, sizeof(uint64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, &magic, sizeof(uint64_t));
+   error_test_def(b_cnt == -1);
    
    // Write sar_bits.
-   if (write(fd, (int64_t *)&(sar->sar_bits), sizeof(int64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, (int64_t *)&(sar->sar_bits), sizeof(int64_t));
+   error_test_def(b_cnt == -1);
 
    // Write sar_len.
-   if (write(fd, (int64_t *)&(sar->sar_len), sizeof(int64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, (int64_t *)&(sar->sar_len), sizeof(int64_t));
+   error_test_def(b_cnt == -1);
 
    // Write Suffix Array.
    e_cnt = 0;
    do {
       b_cnt  = write(fd, (int64_t *)sar->sa + e_cnt, (sar->sar_len - e_cnt)*sizeof(int64_t));
-      if (b_cnt == -1)
-         goto close_and_error;
+      error_test_def(b_cnt == -1);
       e_cnt += b_cnt / sizeof(int64_t);
    } while (e_cnt < sar->sar_len);
 
    close(fd);
    return 0;
 
- close_and_error:
-   close(fd);
+ failure_return:
+   if (fd != -1)
+      close(fd);
    return -1;
 }
 
@@ -215,31 +221,32 @@ sar_file_read
   char   * filename
 )
 {
+   // Declare variables.
+   int fd = -1;
+   sar_t * sar = NULL;
+   int64_t * data = NULL;
+
    // Check arguments.
-   if (filename == NULL)
-      return NULL;
+   error_test_msg(filename == NULL, "argument 'filename' is NULL.");
 
    // Open file.
-   int fd = open(filename, O_RDONLY);
-   if (fd == -1)
-      return NULL;
+   fd = open(filename, O_RDONLY);
+   error_test_def(fd == -1);
 
    // Alloc memory.
-   sar_t * sar = malloc(sizeof(sar_t));
-   if (sar == NULL)
-      goto free_and_return;
+   sar = malloc(sizeof(sar_t));
+   error_test_mem(sar);
+
    // Set NULL pointers.
    sar->sa = NULL;
 
    // Get file len and mmap file.
    struct stat sb;
    fstat(fd, &sb);
-   if (sb.st_size < 24)
-      goto free_and_return;
+   error_test_msg(sb.st_size < 24, "'sar' file size is too small (sb.st_size < 24).");
 
-   int64_t * data = mmap(NULL, sb.st_size, PROT_READ, MAP_SHARED, fd, 0);
-   if (data == NULL)
-      goto free_and_return;
+   data = mmap(NULL, sb.st_size, PROT_READ, MAP_SHARED, fd, 0);
+   error_test_def(data == NULL);
 
    sar->mmap_len = sb.st_size;
    sar->mmap_ptr = (void *) data;
@@ -247,8 +254,7 @@ sar_file_read
    // Read file.
    // Read magic number.
    uint64_t magic = data[0];
-   if (magic != SAR_FILE_MAGICNO)
-      goto free_and_return;
+   error_test_msg(magic != SAR_FILE_MAGICNO, "unrecognized 'sar' file format (magicno).");
 
    sar->sar_bits = data[1];
    sar->sar_len  = data[2];
@@ -258,8 +264,11 @@ sar_file_read
 
    return sar;
 
- free_and_return:
-   close(fd);
+ failure_return:
+   if (fd != 1)
+      close(fd);
+   if (data != NULL)
+      munmap(data, sb.st_size);
    sar_free(sar);
    return NULL;
 }
@@ -306,8 +315,10 @@ compact_array
 
    // Realloc array.
    sar->sa = realloc(sar->sa, sar->sar_len*sizeof(int64_t));
-   if (sar->sa == NULL)
-      return -1;
+   error_test_mem(sar->sa);
 
    return 0;
+
+ failure_return:
+   return -1;
 }

--- a/src/index_sar.h
+++ b/src/index_sar.h
@@ -4,7 +4,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
-
+#include "errhandler.h"
 #include "index_txt.h"
 #include "divsufsort.h"
 

--- a/src/index_sym.c
+++ b/src/index_sym.c
@@ -73,7 +73,6 @@ sym_new
 
    // Check arguments.
    error_test_msg(alphabet == NULL, "argument 'alphabet' is NULL.");
-   error_test_msg(complement == NULL, "argument 'complement' is NULL.");
 
    // Count number of symbols.
    int sym_count = 0;

--- a/src/index_sym.h
+++ b/src/index_sym.h
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "errhandler.h"
 
 #ifndef _INDEX_SYM_H
 #define _INDEX_SYM_H

--- a/src/index_txt.c
+++ b/src/index_txt.c
@@ -650,7 +650,7 @@ txt_file_read
    // Declare variables.
    int fd = -1;
    txt_t * txt = NULL;
-
+   int64_t * data = NULL;
    // Check arguments.
    error_test_msg(filename == NULL, "argument 'filename' is NULL.");
    error_test_msg(sym == NULL, "argument 'sym' is NULL.");
@@ -673,9 +673,9 @@ txt_file_read
    // Get file len and mmap file.
    struct stat sb;
    fstat(fd, &sb);
-   error_test_msg(sb.st_size <= 16, "file size is too small.");
+   error_test_msg(sb.st_size <= 16, "'txt' file size is too small (sb.st_size < 16).");
 
-   int64_t * data = mmap(NULL, sb.st_size, PROT_READ, MAP_SHARED, fd, 0);
+   data = mmap(NULL, sb.st_size, PROT_READ, MAP_SHARED, fd, 0);
    error_test_def(data == NULL);
 
    txt->mmap_len = sb.st_size;
@@ -736,6 +736,8 @@ txt_file_read
  failure_return:
    if (fd != -1)
       close(fd);
+   if (data != NULL)
+      munmap(data, sb.st_size);
    txt_free(txt);
    return NULL;
 }

--- a/src/index_txt.c
+++ b/src/index_txt.c
@@ -28,35 +28,32 @@ txt_new
   sym_t  * sym
 )
 {
-   // Variable names carrying alloc pointers.
+   // Define variables.
    int64_t  * seq_len = NULL, * seq_beg = NULL;
    char    ** seq_name = NULL;
    uint8_t  * text = NULL;
    txt_t    * txt = NULL;
 
    // Check arguments.
-   if (sym == NULL)
-      goto failure_return;
+   error_test_msg(sym == NULL, "argument 'sym' is NULL.");
    
    // Alloc txt_t.
    txt = malloc(sizeof(txt_t));
-
-   if (txt == NULL)
-      goto failure_return;
+   error_test_mem(txt);
 
    // Alloc sequence memory.
    seq_len  = malloc(TXT_SEQ_SIZE*sizeof(uint64_t));
-   seq_beg  = malloc(TXT_SEQ_SIZE*sizeof(uint64_t));
-   seq_name = malloc(TXT_SEQ_SIZE*sizeof(char *));
+   error_test_mem(seq_len);
 
-   if (!seq_len || !seq_beg || !seq_name)
-      goto failure_return;
+   seq_beg  = malloc(TXT_SEQ_SIZE*sizeof(uint64_t));
+   error_test_mem(seq_beg);
+
+   seq_name = malloc(TXT_SEQ_SIZE*sizeof(char *));
+   error_test_mem(seq_name);
 
    // Alloc text memory.
    text = malloc(TXT_BUFFER_SIZE*sizeof(uint8_t));
-
-   if (text == NULL)
-      goto failure_return;
+   error_test_mem(text);
 
    // Initialize and return.
    txt->mmap_len = 0;
@@ -119,13 +116,14 @@ txt_sym
 )
 {
    // Check arguments.
-   if (txt == NULL) 
-      return -1;
-
-   if (pos < 0 || pos >= txt->txt_len)
-      return -1;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+   error_test_msg(pos < 0, "index must be positive.");
+   error_test_msg(pos >= txt->txt_len, "index out of bounds.");
 
    return txt->text[pos];
+   
+ failure_return:
+   return -1;
 }
 
 
@@ -138,14 +136,15 @@ txt_sym_range
 )
 {
    // Check arguments.
-   if (txt == NULL)
-      return NULL;
-   
-   if (beg < 0 || beg + len > txt->txt_len)
-      return NULL;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+   error_test_msg(beg < 0, "index must be positive.");
+   error_test_msg(beg + len > txt->txt_len, "range out of bounds.");
 
    // Since we are not compressing, return pointer to text.
    return txt->text + beg;
+   
+ failure_return:
+   return NULL;
 }
 
 
@@ -156,8 +155,8 @@ txt_append
  txt_t  * txt
 )
 {
-   if (text == NULL || txt == NULL)
-      return -1;
+   error_test_msg(text == NULL, "argument 'text' is NULL.");
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
 
    // Realloc text structure if necessary.
    size_t tlen = strlen(text);
@@ -167,8 +166,7 @@ txt_append
          new_mem_size *= 2;
       }      
       txt->text = realloc(txt->text, new_mem_size * sizeof(uint8_t));
-      if (txt->text == NULL)
-         return -1;
+      error_test_mem(txt->text);
       txt->mem_txt = new_mem_size;
    }
 
@@ -180,6 +178,9 @@ txt_append
    txt->txt_len += tlen;
 
    return 0;
+
+ failure_return:
+   return -1;
 }
 
 int
@@ -192,15 +193,13 @@ txt_append_wildcard
 */
 {
    // Check arguments.
-   if (txt == NULL)
-      return -1;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
 
    // Realloc text structure if necessary.
    if (txt->txt_len >= txt->mem_txt) {
       size_t new_mem_size = txt->mem_txt + 1;
       txt->text = realloc(txt->text, new_mem_size * sizeof(uint8_t));
-      if (txt->text == NULL)
-         return -1;
+      error_test_mem(txt->text);
       txt->mem_txt = new_mem_size;
    }
 
@@ -209,6 +208,9 @@ txt_append_wildcard
    txt->wil_cnt++;
    
    return 0;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -220,35 +222,39 @@ txt_commit_seq
 )
 {
    // Check arguments.
-   if (txt == NULL || seqname == NULL)
-      return -1;
+   error_test_msg(seqname == NULL, "argument 'seqname' is NULL.");
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
    
    // Check seqname length.
-   if (strlen(seqname) < 1)
-      return -1;
+   error_test_msg(strlen(seqname) < 1, "argument 'seqname' is an empty String.");
 
    // Check seqname uniqueness.
    for (int64_t i = 0; i < txt->seq_cnt; i++) {
-      if (strcmp(seqname, txt->seq_name[i]) == 0)
-         return -1;
+      error_test_msg(strcmp(seqname, txt->seq_name[i]) == 0, "duplicate sequence name.");
    }
 
    // Realloc structure if necessary.
    if (txt->txt_len >= txt->mem_txt) {
       size_t new_mem_size = txt->mem_txt + 1;
+
       txt->text = realloc(txt->text, new_mem_size * sizeof(uint8_t));
-      if (txt->text == NULL)
-         return -1;
+      error_test_mem(txt->text);
+
       txt->mem_txt = new_mem_size;
    }
 
    if (txt->seq_cnt >= txt->mem_seq) {
       size_t new_mem_size = 2*txt->mem_seq;
+
       txt->seq_beg  = realloc(txt->seq_beg , new_mem_size * sizeof(uint64_t));
+      error_test_mem(txt->seq_beg);
+
       txt->seq_len  = realloc(txt->seq_len , new_mem_size * sizeof(uint64_t));
+      error_test_mem(txt->seq_len);
+
       txt->seq_name = realloc(txt->seq_name, new_mem_size * sizeof(char *));
-      if (!txt->seq_beg || !txt->seq_len || !txt->seq_name)
-         return -1;
+      error_test_mem(txt->seq_name);
+
       txt->mem_seq = new_mem_size;
    }
 
@@ -265,14 +271,15 @@ txt_commit_seq
    txt->seq_beg[txt->seq_cnt]  = beg;
    txt->seq_len[txt->seq_cnt]  = txt->txt_len - beg;
    txt->seq_name[txt->seq_cnt] = strdup(seqname);
-
-   if (txt->seq_name[txt->seq_cnt] == NULL)
-      return -1;
+   error_test_def(txt->seq_name[txt->seq_cnt] == NULL);
 
    // Update sequence count.
    txt->seq_cnt++;
    
    return 0;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -283,25 +290,24 @@ txt_commit_rc
 )
 {
    // Check arguments.
-   if (txt == NULL)
-      return -1;
-
-   if (txt->txt_len < 1)
-      return 0;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+   error_test_msg(txt->txt_len < 1, "text has length 0.");
 
    // Realloc structure if necessary.
    if (2*txt->txt_len >= txt->mem_txt) {
       size_t new_mem_size = 2*(txt->mem_txt + 1);
       txt->text = realloc(txt->text, new_mem_size * sizeof(uint8_t));
-      if (txt->text == NULL)
-         return -1;
+      error_test_mem(txt->text);
       txt->mem_txt = new_mem_size;
    }
    
    // Append reverse complement of text, including wildcards.
    sym_t  * sym = txt_get_symbols(txt);
+   error_test(sym == NULL);
    int64_t tlen = txt_length(txt);
+   error_test(tlen == -1);
    int     nsym = sym_count(sym);
+   error_test(nsym == -1);
 
    // Add last wildcard if not present.
    if (txt->text[tlen-1] < nsym) {
@@ -329,6 +335,9 @@ txt_commit_rc
    txt->rc_flag = 1;
 
    return 0;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -340,10 +349,12 @@ txt_length
 )
 {
    // Check arguments.
-   if (txt == NULL)
-      return -1;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
 
    return txt->txt_len;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -354,10 +365,12 @@ txt_get_symbols
 )
 {
    // Check arguments.
-   if (txt == NULL)
-      return NULL;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
    
    return txt->sym;
+
+ failure_return:
+   return NULL;
 }
 
 
@@ -368,10 +381,12 @@ txt_wildcard_count
 )
 {
    // Check arguments.
-   if (txt == NULL) 
-      return -1;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
 
    return txt->wil_cnt;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -382,10 +397,12 @@ txt_seq_count
 )
 {
    // Check arguments.
-   if (txt == NULL) 
-      return -1;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
 
    return txt->seq_cnt;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -396,12 +413,14 @@ txt_seq_start
   txt_t    * txt
 )
 {
-   if (txt == NULL)
-      return -1;
-   if (seq < 0 || seq >= txt->seq_cnt)
-      return -1;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+   error_test_msg(seq < 0, "index must be positive.");
+   error_test_msg(seq >= txt->seq_cnt, "index out of bounds.");
 
    return txt->seq_beg[seq];
+
+ failure_return:
+   return -1;
 }
 
 
@@ -412,12 +431,14 @@ txt_seq_length
   txt_t    * txt
 )
 {
-   if (txt == NULL)
-      return -1;
-   if (seq < 0 || seq >= txt->seq_cnt)
-      return -1;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+   error_test_msg(seq < 0, "index must be positive.");
+   error_test_msg(seq >= txt->seq_cnt, "index out of bounds.");
 
    return txt->seq_len[seq];
+
+ failure_return:
+   return -1;
 }
 
 
@@ -428,12 +449,14 @@ txt_seq_name
   txt_t    * txt
 )
 {
-   if (txt == NULL)
-      return NULL;
-   if (seq < 0 || seq >= txt->seq_cnt)
-      return NULL;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+   error_test_msg(seq < 0, "index must be positive.");
+   error_test_msg(seq >= txt->seq_cnt, "index out of bounds.");
 
    return txt->seq_name[seq];
+   
+ failure_return:
+   return NULL;
 }
 
 
@@ -444,10 +467,9 @@ txt_pos_to_str
   txt_t    * txt
 )
 {
-   if (txt == NULL)
-      return NULL;
-   if (pos < 0 || pos >= txt->txt_len)
-      return NULL;
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
+   error_test_msg(pos < 0, "index must be positive.");
+   error_test_msg(pos >= txt->txt_len, "index out of bounds.");
 
    // Check whether text has RC.
    int strand = 0;
@@ -461,12 +483,14 @@ txt_pos_to_str
 
    // Generate string.
    char * pos_str = malloc(strlen(txt->seq_name[seq_id])+30);
-   if (pos_str == NULL)
-      return NULL;
+   error_test_mem(pos_str);
 
    sprintf(pos_str, "%s:%ld:%c", txt->seq_name[seq_id], pos - txt->seq_beg[seq_id] + 1, (strand ? '-' : '+'));
 
    return pos_str;
+
+ failure_return:
+   return NULL;
 }
 
 
@@ -477,12 +501,11 @@ txt_str_to_pos
   txt_t  * txt
 )
 {
-   if (str == NULL || txt == NULL)
-      return -1;
+   error_test_msg(str == NULL, "argument 'str' is NULL.");
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
 
    char * pos_str = strdup(str);
-   if (pos_str == NULL)
-      return -1;
+   error_test_def(pos_str == NULL);
 
    // Tokenize string.
    char * seq_name = strtok(pos_str, ":");
@@ -490,8 +513,7 @@ txt_str_to_pos
    char * seq_fw   = strtok(NULL, ":");
 
    // Incorrect format.
-   if (seq_pos == NULL)
-      return -1;
+   error_test_msg(seq_pos == NULL, "incorrect sequence format.");
 
    // Read strand (default is '+').
    int strand = 1;
@@ -506,13 +528,12 @@ txt_str_to_pos
          break;
       }
    }
-   if (seq_id < 0)
-      return -1;
+   error_test_msg(seq_id < 0, "sequence name not found.");
 
    // Convert position to int.
    int64_t pos = atol(seq_pos);
-   if (pos < 1 || pos > txt->seq_len[seq_id])
-      return -1;
+   error_test_msg(pos < 1, "sequence index must be positive");
+   error_test_msg(pos > txt->seq_len[seq_id], "sequence index out of bounds");
 
    // Find position in sequence.
    pos = txt->seq_beg[seq_id] + pos - 1;
@@ -524,6 +545,9 @@ txt_str_to_pos
    
    // Return absolute position.
    return pos;
+
+ failure_return:
+   return -1;
 }
 
 
@@ -535,14 +559,14 @@ txt_file_write
   txt_t  * txt
 )
 {
+   int fd = -1;
    // Check arguments.
-   if (filename == NULL || txt == NULL)
-      return -1;
+   error_test_msg(filename == NULL, "argument 'filename' is NULL.");
+   error_test_msg(txt == NULL, "argument 'txt' is NULL.");
    
    // Open file.
-   int fd = creat(filename, 0644);
-   if (fd == -1)
-      return -1;
+   fd = creat(filename, 0644);
+   error_test_def(fd == -1);
 
    // Write data.
    ssize_t  e_cnt = 0;
@@ -550,31 +574,30 @@ txt_file_write
    uint64_t magic = TXT_FILE_MAGICNO;
 
    // Write magic.
-   if (write(fd, &magic, sizeof(uint64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, &magic, sizeof(uint64_t));
+   error_test_def(b_cnt == -1);
 
    // Write txt_len.
-   if (write(fd, (int64_t *)&(txt->txt_len), sizeof(int64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, (int64_t *)&(txt->txt_len), sizeof(int64_t));
+   error_test_def(b_cnt == -1);
 
    // write seq_cnt.
-   if (write(fd, (int64_t *)&(txt->seq_cnt), sizeof(int64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, (int64_t *)&(txt->seq_cnt), sizeof(int64_t));
+   error_test_def(b_cnt == -1);
 
    // write wil_cnt.
-   if (write(fd, (int64_t *)&(txt->wil_cnt), sizeof(int64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, (int64_t *)&(txt->wil_cnt), sizeof(int64_t));
+   error_test_def(b_cnt == -1);
 
    // write rc_flag.
-   if (write(fd, (int64_t *)&(txt->rc_flag), sizeof(int64_t)) == -1)
-      goto close_and_error;
+   b_cnt = write(fd, (int64_t *)&(txt->rc_flag), sizeof(int64_t));
+   error_test_def(b_cnt == -1);
 
    // write seq_len array.
    e_cnt = 0;
    do {
       b_cnt  = write(fd, (int64_t *)txt->seq_len + e_cnt, (txt->seq_cnt - e_cnt)*sizeof(int64_t));
-      if (b_cnt == -1)
-         goto close_and_error;
+      error_test_def(b_cnt == -1);
       e_cnt += b_cnt / sizeof(int64_t);
    } while (e_cnt < txt->seq_cnt);
 
@@ -583,8 +606,7 @@ txt_file_write
    e_cnt = 0;
    do {
       b_cnt  = write(fd, (int64_t *)txt->seq_beg + e_cnt, (txt->seq_cnt - e_cnt)*sizeof(int64_t));
-      if (b_cnt == -1)
-         goto close_and_error;
+      error_test_def(b_cnt == -1);
       e_cnt += b_cnt / sizeof(int64_t);
    } while (e_cnt < txt->seq_cnt);
 
@@ -594,8 +616,7 @@ txt_file_write
       e_cnt = 0;
       do {
          b_cnt  = write(fd, (char *)txt->seq_name[i] + e_cnt, (namelen - e_cnt)*sizeof(char));
-         if (b_cnt == -1)
-            goto close_and_error;
+         error_test_def(b_cnt == -1);
          e_cnt += b_cnt / sizeof(char);
       } while (e_cnt < namelen);
    }
@@ -604,16 +625,16 @@ txt_file_write
    e_cnt = 0;
    do {
       b_cnt  = write(fd, (uint8_t *)txt->text + e_cnt, (txt->txt_len - e_cnt)*sizeof(uint8_t));
-      if (b_cnt == -1)
-         goto close_and_error;
+      error_test_def(b_cnt == -1);
       e_cnt += b_cnt / sizeof(uint8_t);
    } while (e_cnt < txt->txt_len);
 
    close(fd);
    return 0;
 
- close_and_error:
-   close(fd);
+ failure_return:
+   if (fd != -1)
+      close(fd);
    return -1;
 }
 
@@ -626,18 +647,20 @@ txt_file_read
   sym_t  * sym
 )
 {
+   // Declare variables.
+   int fd = -1;
+   txt_t * txt = NULL;
+
    // Check arguments.
-   if (filename == NULL || sym == NULL)
-      return NULL;
+   error_test_msg(filename == NULL, "argument 'filename' is NULL.");
+   error_test_msg(sym == NULL, "argument 'sym' is NULL.");
 
    // Open file.
-   int fd = open(filename, O_RDONLY);
-   if (fd == -1)
-      return NULL;
+   fd = open(filename, O_RDONLY);
+   error_test_def(fd == -1);
 
-   txt_t * txt = malloc(sizeof(txt_t));
-   if (txt == NULL)
-      goto free_and_return;
+   txt = malloc(sizeof(txt_t));
+   error_test_mem(txt);
 
    // Set NULL pointers.
    txt->mmap_len = 0;
@@ -650,12 +673,10 @@ txt_file_read
    // Get file len and mmap file.
    struct stat sb;
    fstat(fd, &sb);
-   if (sb.st_size <= 16)
-      goto free_and_return;
+   error_test_msg(sb.st_size <= 16, "file size is too small.");
 
    int64_t * data = mmap(NULL, sb.st_size, PROT_READ, MAP_SHARED, fd, 0);
-   if (data == NULL)
-      goto free_and_return;
+   error_test_def(data == NULL);
 
    txt->mmap_len = sb.st_size;
    txt->mmap_ptr = (void *) data;
@@ -663,26 +684,23 @@ txt_file_read
    // Read file.
    // Read magic number.
    uint64_t magic = data[0];
-   if (magic != TXT_FILE_MAGICNO)
-      goto free_and_return;
+   error_test_msg(magic != TXT_FILE_MAGICNO, "unrecognized 'txt' file format (magicno).");
 
    // Read 'txt_len'.
    txt->txt_len = data[1];
-   if (txt->txt_len < 1)
-      goto free_and_return;
+   error_test_msg(txt->txt_len < 1, "incorrect 'txt' file format (txt_len < 1).");
 
    // Read 'seq_cnt'.
    txt->seq_cnt = data[2];
-   if (txt->seq_cnt < 1)
-      goto free_and_return;
+   error_test_msg(txt->seq_cnt < 1, "incorrect 'txt' file format (seq_cnt < 1).");
 
    // Read 'seq_cnt'.
    txt->wil_cnt = data[3];
 
    // Read 'rc_flag'.
    txt->rc_flag = data[4];
-   if (txt->rc_flag < 0 || txt->rc_flag > 1)
-      goto free_and_return;
+   error_test_msg(txt->rc_flag < 0, "incorrect 'txt' file format (rc_flag < 0).");
+   error_test_msg(txt->rc_flag > 1, "incorrect 'txt' file format (rc_flag > 1).");
    
    // Pointer to seq_beg array.
    txt->seq_len = data + 5;
@@ -692,8 +710,7 @@ txt_file_read
 
    // Alloc sequence names.
    txt->seq_name = malloc(txt->seq_cnt * sizeof(char *));
-   if (txt->seq_name == NULL)
-      return NULL;
+   error_test_mem(txt->seq_name);
 
    // Pointers to seq_names.
    char * str_ptr = (char *) (txt->seq_beg + txt->seq_cnt);
@@ -716,8 +733,9 @@ txt_file_read
 
    return txt;
    
- free_and_return:
-   close(fd);
+ failure_return:
+   if (fd != -1)
+      close(fd);
    txt_free(txt);
    return NULL;
 }

--- a/src/index_txt.h
+++ b/src/index_txt.h
@@ -7,7 +7,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
+#include "errhandler.h"
 #include "index_sym.h"
+
 
 #ifndef _INDEX_TXT_H
 #define _INDEX_TXT_H

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,8 +6,8 @@ SOURCE_DIR= ../src
 HEADER_DIR= $(SOURCE_DIR)
 
 OBJECTS= test_index_sym.o test_index_txt.o test_index_sar.o test_index_bwt.o test_index_ann.o test_index.o libunittest.so
-SOURCE= index_sym.c index_txt.c index_sar.c index_bwt.c index_ann.c index.c blocksearch.c divsufsort.c
-HEADER= index_sym.h index_txt.h index_sar.h index_bwt.h index_ann.h index.h blocksearch.h divsufsort.h divsufsort_private.h
+SOURCE= index_sym.c index_txt.c index_sar.c index_bwt.c index_ann.c index.c blocksearch.c errhandler.c divsufsort.c
+HEADER= index_sym.h index_txt.h index_sar.h index_bwt.h index_ann.h index.h blocksearch.h errhandler.h divsufsort.h divsufsort_private.h
 INCLUDE= lib $(SOURCE_DIR) $(HEADER_DIR)
 COVFILE= blocksearch.gcno index_sym.gcno index_txt.gcno index_bwt.gcno index_sar.gcno index_ann.gcno index.gcno
 

--- a/test/test_index.c
+++ b/test/test_index.c
@@ -5,6 +5,7 @@ void
 test_index_build
 (void)
 {
+   redirect_stderr();
    test_assert(index_build("fakefile.fasta", "test_base") == NULL);
    test_assert(index_build(NULL, "test_base") == NULL);
    test_assert(index_build("examples/repeats.fa", NULL) == NULL);
@@ -42,12 +43,14 @@ test_index_build
    free(q);
 
    index_free(index);
+   unredirect_stderr();
 }
 
 void
 test_index_ann_new
 (void)
 {
+   redirect_stderr();
    index_t * index = index_build("examples/repeats.fa", "test_base01");
    test_assert_critical(index != NULL);
 
@@ -82,6 +85,7 @@ test_index_ann_new
    free(lci);
 
    index_free(index);
+   unredirect_stderr();
 }
 
 
@@ -89,6 +93,7 @@ void
 test_index_read
 (void)
 {
+   redirect_stderr();
    index_t * index = index_build("examples/repeats.fa", "test_base02");
    test_assert_critical(index != NULL);
 
@@ -156,6 +161,8 @@ test_index_read
    free(lci);
 
    index_free(index);
+
+   unredirect_stderr();
 }
 
 

--- a/test/test_index_bwt.c
+++ b/test/test_index_bwt.c
@@ -27,8 +27,10 @@ test_bwt_build
    test_assert(sar_get_range(0,32,sa_buf,sar) == 0);
    test_assert(memcmp(sa_buf, sa_ref, 32*sizeof(int64_t)) == 0);
 
+   redirect_stderr();
    test_assert(bwt_build(NULL, sar) == NULL);
    test_assert(bwt_build(txt, NULL) == NULL);
+   unredirect_stderr();
 
    bwt_t * bwt = bwt_build(txt, sar);
    test_assert_critical(bwt != NULL);
@@ -320,8 +322,11 @@ test_bwt_new_query
    bwt_t * bwt = bwt_build(txt, sar);
    test_assert_critical(bwt != NULL);
 
+   redirect_stderr();
    bwtquery_t * q = bwt_new_query(NULL);
+   unredirect_stderr();
    test_assert(q == NULL);
+
    
    q = bwt_new_query(bwt);   
    test_assert_critical(q != NULL);
@@ -357,7 +362,9 @@ test_bwt_dup_query
    bwt_t * bwt = bwt_build(txt, sar);
    test_assert_critical(bwt != NULL);
 
+   redirect_stderr();
    bwtquery_t * q = bwt_new_query(NULL);
+   unredirect_stderr();
    test_assert(q == NULL);
    
    q = bwt_new_query(bwt);   
@@ -366,7 +373,9 @@ test_bwt_dup_query
    test_assert(bwt_size(q) == 32);
    test_assert(bwt_depth(q) == 0);
 
+   redirect_stderr();
    bwtquery_t * q2 = bwt_dup_query(NULL);
+   unredirect_stderr();
    test_assert(q2 == NULL);
 
    q2 = bwt_dup_query(q);
@@ -418,9 +427,11 @@ test_bwt_new_vec
    bwt_t * bwt = bwt_build(txt, sar);
    test_assert_critical(bwt != NULL);
 
+   redirect_stderr();
    bwtquery_t ** qv = bwt_new_vec(NULL);
+   unredirect_stderr();
    test_assert(qv == NULL);
-   
+
    qv = bwt_new_vec(bwt);
    test_assert_critical(qv != NULL);
    test_assert(bwt_start(qv[0]) == 0);
@@ -552,6 +563,7 @@ test_bwt_query
    bwtquery_t * q = bwt_new_query(bwt);
    test_assert_critical(q != NULL);
 
+   redirect_stderr();
    test_assert(bwt_query(-1, BWT_QUERY_SUFFIX, q, q) == -1);
    test_assert(bwt_query(sym_count(sym), BWT_QUERY_SUFFIX, q, q) == -1);
    test_assert(bwt_query(sym_index('A',sym), 3498, q, q) == -1);
@@ -560,7 +572,7 @@ test_bwt_query
    test_assert(bwt_start(q) == 0);
    test_assert(bwt_size(q) == 32);
    test_assert(bwt_depth(q) == 0);
-
+   unredirect_stderr();
 
    bwt_query(sym_index('A',sym), BWT_QUERY_SUFFIX, q, q);
    test_assert(bwt_start(q) == 2);
@@ -652,6 +664,7 @@ test_bwt_query_all
    bwtquery_t ** q0 = bwt_new_vec(bwt);
    test_assert_critical(q0 != NULL);
 
+   redirect_stderr();
    test_assert(bwt_query_all(1023, q0[0], q0) == -1);
    test_assert(bwt_query_all(-1, q0[0], q0) == -1);
    test_assert(bwt_query_all(BWT_QUERY_SUFFIX, NULL, q0) == -1);
@@ -659,7 +672,10 @@ test_bwt_query_all
    free(q0[2]);
    q0[2] = NULL;
    test_assert(bwt_query_all(BWT_QUERY_SUFFIX, q0[0], q0) == -1);
+   unredirect_stderr();
+
    bwt_free_vec(q0);
+   
 
    q0 = bwt_new_vec(bwt);
    test_assert_critical(q0 != NULL);
@@ -745,14 +761,17 @@ test_bwt_prefix
    test_assert(bwt_size(q) == 32);
    test_assert(bwt_depth(q) == 0);
    
+   redirect_stderr();
    test_assert(bwt_prefix(sym_index('A',sym), NULL, q) == -1);
    test_assert(bwt_prefix(sym_index('A',sym), q, NULL) == -1);
    test_assert(bwt_prefix(sym_index('A',sym), q, NULL) == -1);
    test_assert(bwt_prefix(-1, q, q) == -1);
    test_assert(bwt_prefix(sym_count(sym), q, q) == -1);
+   unredirect_stderr();
    test_assert(bwt_start(q) == 0);
    test_assert(bwt_size(q) == 32);
    test_assert(bwt_depth(q) == 0);
+
 
    test_assert(bwt_prefix(sym_index('a',sym), q, q) == 0);
    test_assert(bwt_start(q) == 2);
@@ -810,12 +829,14 @@ test_bwt_prefix_all
    bwtquery_t ** qv = bwt_new_vec(bwt);
    test_assert_critical(qv != NULL);
 
+   redirect_stderr();
    test_assert(bwt_prefix_all(NULL, NULL) == -1);
    test_assert(bwt_prefix_all(NULL, qv) == -1);
    test_assert(bwt_prefix_all(qv[0], NULL) == -1);
    free(qv[1]);
    qv[1] = NULL;
    test_assert(bwt_prefix_all(qv[0], qv) == -1);
+   unredirect_stderr();
    
    bwt_free_vec(qv);
 
@@ -870,8 +891,11 @@ test_bwt_get_text
    bwt_t * bwt = bwt_build(txt, sar);
    test_assert_critical(bwt != NULL);
 
+   redirect_stderr();
    test_assert(bwt_get_text(NULL) == NULL);
+   unredirect_stderr();
    test_assert(bwt_get_text(bwt) == txt);
+
 
    bwt_free(bwt);
    sar_free(sar);
@@ -903,7 +927,9 @@ test_bwt_get_bwt
    bwtquery_t * q = bwt_new_query(bwt);
    test_assert_critical(q != NULL);
 
+   redirect_stderr();
    test_assert(bwt_get_bwt(NULL) == NULL);
+   unredirect_stderr();
    test_assert(bwt_get_bwt(q) == bwt);
 
    free(q);
@@ -938,9 +964,11 @@ test_bwt_helpers
    bwtquery_t * q = bwt_new_query(bwt);
    test_assert_critical(q != NULL);
    
+   redirect_stderr();
    test_assert(bwt_start(NULL) == -1);
    test_assert(bwt_size(NULL) == -1);
    test_assert(bwt_depth(NULL) == -1);
+   unredirect_stderr();
    test_assert(bwt_start(q) == 0);
    test_assert(bwt_size(q) == 32);
    test_assert(bwt_depth(q) == 0);

--- a/test/test_index_sar.c
+++ b/test/test_index_sar.c
@@ -16,6 +16,8 @@ test_sar_build
    char   * seq_5   = "$TgAgcatGGC$acTCGA$";
    int64_t  sar_5[] = {18,11,0,17,12,3,6,10,5,15,13,16,2,9,4,8,14,1,7};
 
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
 
@@ -127,6 +129,8 @@ test_sar_build
    txt_free(txt);
    sym_free(sym);
    free(sa_buf);
+
+   unredirect_stderr();
 }
 
 
@@ -134,6 +138,8 @@ void
 test_sar_get
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    txt_t * txt = txt_new(sym);
@@ -171,6 +177,8 @@ test_sar_get
    sar_free(sar);
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -178,6 +186,8 @@ void
 test_sar_get_range
 (void)
 {
+   redirect_stderr();
+
    int64_t  ref_sa[] = {18,11,0,17,12,3,6,10,5,15,13,16,2,9,4,8,14,1,7};
    int64_t * sa_buf = malloc(30*sizeof(int64_t));
    test_assert_critical(sa_buf != NULL);
@@ -207,6 +217,8 @@ test_sar_get_range
    txt_free(txt);
    sym_free(sym);
    free(sa_buf);
+
+   unredirect_stderr();
 }
 
 
@@ -214,6 +226,8 @@ void
 test_sar_file
 (void)
 {
+   redirect_stderr();
+
    int64_t  ref_sa[] = {18,11,0,17,12,3,6,10,5,15,13,16,2,9,4,8,14,1,7};
    int64_t * sa_buf = malloc(30*sizeof(int64_t));
    test_assert_critical(sa_buf != NULL);
@@ -272,6 +286,8 @@ test_sar_file
    txt_free(txt);
    sym_free(sym);
    free(sa_buf);
+
+   unredirect_stderr();
 }
 
 // Define test cases to be run (for export).

--- a/test/test_index_sym.c
+++ b/test/test_index_sym.c
@@ -16,6 +16,8 @@ test_sym_new
    char * comp03[] = {"aB", "BA", "CD", "DC", NULL};
    char * comp04[] = {"AB", "BA", "CD", "dc", NULL};
    char * comp05[] = {"AB", "BA", "CD", "DC", NULL};
+
+   redirect_stderr();
    // NULL alphabet.
    sym_t * sym0 = sym_new(NULL, NULL, 0);
    test_assert(sym0 == NULL);
@@ -213,7 +215,7 @@ test_sym_new
    test_assert(sym_complement(3, sym2) == 0);
    test_assert(sym_complement(4, sym2) == 2);
    sym_free(sym2);
-
+   unredirect_stderr();
 }
 
 void
@@ -227,6 +229,7 @@ test_sym_set_complement
    char * comp03[] = {NULL};
    char * comp04[] = {"AA","BA","CD","DD",NULL};
 
+   redirect_stderr();
    test_assert(sym_set_complement(NULL, NULL) == -1);
    test_assert(sym_set_complement(comp00, NULL) == -1);
 
@@ -285,6 +288,7 @@ test_sym_set_complement
    test_assert(sym_set_complement(wrong03, sym) == -1);
 
    sym_free(sym);
+   unredirect_stderr();
 }
 
 void
@@ -294,6 +298,8 @@ test_sym_character
    sym_t * sym;
    char * alph0[] = {"Aa","Bb","Cc","Dd","Ee",NULL};
    char * alph1[] = {"aA","Bb","cC","Dd","eE",NULL};
+
+   redirect_stderr();
 
    test_assert(sym_character(0, NULL) == -1);
    
@@ -322,6 +328,8 @@ test_sym_character
    test_assert(sym_character(6, sym) == -1);
    test_assert(sym_character(-1, sym) == -1);
    sym_free(sym);   
+
+   unredirect_stderr();
 }
 
 void
@@ -331,6 +339,8 @@ test_sym_index
    sym_t * sym;
    char * alph0[] = {"Aa","Bb","Cc","Dd","Ee",NULL};
    char * alph1[] = {"aA","Bb","cC","Dd","eE",NULL};
+
+   redirect_stderr();
 
    test_assert(sym_index(0, NULL) == -1);
    
@@ -372,6 +382,7 @@ test_sym_index
    test_assert(sym_character(sym_index('9', sym), sym) == 'c');
    sym_free(sym);
 
+   unredirect_stderr();
 }
 
 void
@@ -381,6 +392,8 @@ test_sym_is_canonical
    sym_t * sym;
    char * alph0[] = {"Aa","Bb","Cc","Dd","Ee",NULL};
    char * alph1[] = {"aA","Bb","cC","Dd","eE",NULL};
+
+   redirect_stderr();
 
    test_assert(sym_is_canonical(0, NULL) == -1);
    
@@ -423,6 +436,8 @@ test_sym_is_canonical
    test_assert(sym_is_canonical('%',sym) == 0);
    test_assert(sym_is_canonical('$',sym) == 0);
    sym_free(sym);   
+
+   unredirect_stderr();
 }
 
 void
@@ -434,6 +449,8 @@ test_sym_complement
    char * comp01[] = {"AC","BD",NULL};
    char * comp02[] = {"AB","BA","CD","DC",NULL};
    char * comp03[] = {NULL};
+
+   redirect_stderr();
 
    sym_t * sym;
    sym = sym_new(alph0, NULL, 0);
@@ -483,6 +500,8 @@ test_sym_complement
    test_assert(sym_complement(-1, sym) == -1);
 
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 void
@@ -495,6 +514,8 @@ test_sym_count
    char * alph3[] = {"a","b","c","d","e","fF","gG","h","iI","Jj",NULL};
    char * alph4[] = {"a","b",NULL};
 
+   redirect_stderr();
+ 
    sym_t * sym;
    sym = sym_new(alph0, NULL, 0);
    test_assert_critical(sym != NULL);
@@ -520,6 +541,8 @@ test_sym_count
    test_assert_critical(sym != NULL);
    test_assert(sym_count(sym) == 2);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 void
@@ -530,6 +553,8 @@ test_sym_file
    char * alph1[] = {"k", "Jm", "Ti", "jCd", "Nn", NULL};
    char * comp00[] = {"AB","CD",NULL};
    char * comp10[] = {"kT","Jj","jk","TJ",NULL};
+
+   redirect_stderr();
 
    sym_t * sym_o, * sym_i;
    sym_o = sym_new(alph0, NULL, 0);
@@ -709,6 +734,8 @@ test_sym_file
    test_assert(sym_complement(3, sym_i) == 0);
    test_assert(sym_complement(4, sym_i) == 4);
    sym_free(sym_i);
+
+   unredirect_stderr();
 }
 
 // Define test cases to be run (for export).

--- a/test/test_index_txt.c
+++ b/test/test_index_txt.c
@@ -7,6 +7,8 @@ test_txt_new
 {
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
+
+   redirect_stderr();
    
    txt_t * txt;
 
@@ -42,6 +44,8 @@ test_txt_new
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -49,6 +53,8 @@ void
 test_txt_sym
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -81,6 +87,8 @@ test_txt_sym
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -88,6 +96,8 @@ void
 test_txt_sym_range
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -134,6 +144,8 @@ test_txt_sym_range
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -141,6 +153,8 @@ void
 test_txt_append
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -210,6 +224,8 @@ test_txt_append
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -217,6 +233,8 @@ void
 test_txt_append_wildcard
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -252,6 +270,8 @@ test_txt_append_wildcard
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -259,6 +279,8 @@ void
 test_txt_commit_seq
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -297,6 +319,8 @@ test_txt_commit_seq
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -304,6 +328,8 @@ void
 test_txt_commit_rc
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -404,6 +430,8 @@ test_txt_commit_rc
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -411,6 +439,8 @@ void
 test_txt_length
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
 
@@ -435,6 +465,8 @@ test_txt_length
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -442,6 +474,8 @@ void
 test_txt_wildcard_count
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
 
@@ -463,6 +497,8 @@ test_txt_wildcard_count
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -470,6 +506,8 @@ void
 test_txt_get_symbols
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -481,6 +519,8 @@ test_txt_get_symbols
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -488,6 +528,8 @@ void
 test_txt_seq_helpers
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -523,6 +565,8 @@ test_txt_seq_helpers
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -530,6 +574,8 @@ void
 test_txt_pos_to_str
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -555,12 +601,16 @@ test_txt_pos_to_str
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 void
 test_txt_str_to_pos
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -594,6 +644,8 @@ test_txt_str_to_pos
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 
@@ -602,6 +654,8 @@ void
 test_txt_file
 (void)
 {
+   redirect_stderr();
+
    sym_t * sym = sym_new_dna();
    test_assert_critical(sym != NULL);
    
@@ -685,6 +739,8 @@ test_txt_file
 
    txt_free(txt);
    sym_free(sym);
+
+   unredirect_stderr();
 }
 
 


### PR DESCRIPTION
## Description
The library `errhandler.h` defines the following macros, which end in a jump to the `failure_return` label:
- `error_test_mem(x)`: compares `x` to NULL, if `true` throws error and prints "memory error" in a warning message.
- `error_test_def(x)`: evaluates `x`, if `true`throws error and  prints error string provided by `strerror()`. This is to be used to check errors on calls to standard library functions which set `errno` upon error, like `fopen`, `mmap`, `write`, etc.
- `error_test_msg(x, m)`: evaluates `x`, if `true` throws error and prints `m` in a warning message.
- `error_throw_def()`: throws unconditional error and prints string provided by `strerror()` in a warning message.
- `error_throw_msg(m)`: throws unconditional error and prints string `m` in a warning message.
- `error_test(x)`: evaluates `x`, if `true` throws error and prints stack info. Used to propagate error.
- `error_throw()`: throws unconditional error and prints stack info. Used to propagate error.

Current project files have been updated to use error check and propagation. Error checking has been omitted only when potential error causes have been checked before, i.e. in calls to parent functions.

## Related issues.
Closes #37.
